### PR TITLE
Add "cache_options" key, which is forwarded to MemCached.  Used for "expires_in: 3.days" functionality

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -18,6 +18,7 @@ module MultiFetchFragments
 
       if ActionController::Base.perform_caching && @options[:cache].present?
 
+        additional_cache_options = @options.fetch(:cache_options, {})
         keys_to_collection_map = {}
 
         @collection.each do |item| 
@@ -58,7 +59,7 @@ module MultiFetchFragments
             results << cached_value
           else
             non_cached_result = non_cached_results.shift
-            Rails.cache.write(key, non_cached_result)
+            Rails.cache.write(key, non_cached_result, additional_cache_options)
 
             results << non_cached_result
           end


### PR DESCRIPTION
I often have data that goes stale, even if the cache-key is the same.  For example, I'll render "3 days ago", which needs to expire after a day.  Or, I'll pull in the build-status into our dev bar from CircleCI.  No cache-key, but I only want to poll every 5 minutes.

This pull request adds support for the key "cache_options" in the render call.  Any options passed in are forwarded to the Rails.cache.write call, which will take care of forwarding on to MemCached.  More options are described in the [Rails Caching guide](http://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-store).
