### PR TITLE
Dalli 2.6 requires mutable keys for read_multi and write

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -27,7 +27,10 @@ module MultiFetchFragments
           keys_to_collection_map[expanded_key] = item
         end
 
-        result_hash = Rails.cache.read_multi(keys_to_collection_map.keys)
+        # cache.read_multi & cache.write interfaces may require mutable keys, ie. dalli 2.6.0
+        mutable_keys = keys_to_collection_map.keys.collect { |key| key.dup }
+
+        result_hash = Rails.cache.read_multi(mutable_keys)
 
         # if we had a cached value, we don't need to render that object from the collection. 
         # if it wasn't cached, we need to render those objects as before
@@ -46,7 +49,7 @@ module MultiFetchFragments
         end
 
         # sort the result according to the keys that were fed in, cache the non-cached results
-        keys_to_collection_map.each do |key, value|
+        mutable_keys.each do |key|
 
           cached_value = result_hash[key]
           if cached_value


### PR DESCRIPTION
I was playing around and doing some performance measurements, but came across this error in my test app:

```
dalli (2.6.0) lib/active_support/cache/dalli_store.rb:270:in `force_encoding'
dalli (2.6.0) lib/active_support/cache/dalli_store.rb:270:in `expanded_key'
dalli (2.6.0) lib/active_support/cache/dalli_store.rb:128:in `block in read_multi'
dalli (2.6.0) lib/active_support/cache/dalli_store.rb:128:in `each'
dalli (2.6.0) lib/active_support/cache/dalli_store.rb:128:in `inject'
dalli (2.6.0) lib/active_support/cache/dalli_store.rb:128:in `read_multi'
multi_fetch_fragments (0.0.9) lib/multi_fetch_fragments.rb:32:in `render_collection_with_multi_fetch_cache'
```

It seems that the 2.6.0 bump brought in https://github.com/mperham/dalli/commit/aa7ff874dc3e522ad9255f363705a660d6727e7a which now requires that the given keys to cache.read_multi and cache.write must be mutable.
