### PR TITLE
Compatability fix with dalli_store

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -54,7 +54,8 @@ module MultiFetchFragments
             results << cached_value
           else
             non_cached_result = non_cached_results.shift
-            Rails.cache.write(key, non_cached_result, additional_cache_options)
+            # Keys from a hash are freezed and memcached may need to touch them
+            Rails.cache.write(key.dup, non_cached_result, additional_cache_options)
 
             results << non_cached_result
           end

--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -27,7 +27,8 @@ module MultiFetchFragments
           keys_to_collection_map[expanded_key] = item
         end
 
-        result_hash = Rails.cache.read_multi(keys_to_collection_map.keys)
+        # Keys from a hash are freezed and memcached may need to touch them
+        result_hash = Rails.cache.read_multi(keys_to_collection_map.keys.map(&:dup))
 
         # if we had a cached value, we don't need to render that object from the collection. 
         # if it wasn't cached, we need to render those objects as before

--- a/spec/models/customer.rb
+++ b/spec/models/customer.rb
@@ -1,2 +1,5 @@
 class Customer < Struct.new(:name, :id)
+  def cache_key
+    "#{id}:#{name}"
+  end
 end

--- a/spec/multi_fetch_fragments_spec.rb
+++ b/spec/multi_fetch_fragments_spec.rb
@@ -7,4 +7,16 @@ describe MultiFetchFragments do
     view = ActionView::Base.new([File.dirname(__FILE__)], {})
     view.render(:partial => "views/customer", :collection => [ Customer.new("david"), Customer.new("mary") ]).should == "Hello: david\nHello: mary\n"
   end
+
+  it "passing in a custom key works" do
+    cache_mock = mock()
+    RAILS_CACHE = cache_mock
+    MultiFetchFragments::Railtie.run_initializers
+
+    view = ActionView::Base.new([File.dirname(__FILE__)], {})
+    customer = Customer.new("david")
+    key = ActiveSupport::Cache.expand_cache_key([customer, 'key'])
+    cache_mock.should_receive(:read_multi).with([key]).and_return({key => 'Hello'})
+    view.render(:partial => "views/customer", :collection => [ customer ], :cache => Proc.new{ |item| [item, 'key']}).should == "Hello"
+  end
 end


### PR DESCRIPTION
Dalli (at least in 1.1.3) needs to access the keys for escaping. Keys from hashes are freezed which raised an exception.

Also added a minor test for actually running the cache partial code using a custom cache key.
