### PR TITLE
Support short-hand partial rendering syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    multi_fetch_fragments (0.0.12)
+    multi_fetch_fragments (0.0.13)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -16,7 +16,7 @@ module MultiFetchFragments
 
       results = []
 
-      if ActionController::Base.perform_caching && @options[:cache].present?
+      if cache_collection?
 
         additional_cache_options = @options.fetch(:cache_options, {})
         keys_to_collection_map = {}
@@ -79,6 +79,11 @@ module MultiFetchFragments
       end
 
       results.join(spacer).html_safe
+    end
+
+    def cache_collection?
+      cache_option = @options[:cache].presence || @locals[:cache].presence
+      ActionController::Base.perform_caching && cache_option
     end
 
   class Railtie < Rails::Railtie

--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -34,7 +34,7 @@ module MultiFetchFragments
             key_with_optional_digest = key
           end
 
-          expanded_key = @view.controller.fragment_cache_key(key_with_optional_digest) 
+          expanded_key = @view.controller.fragment_cache_key(key_with_optional_digest)
 
           keys_to_collection_map[expanded_key] = item
         end
@@ -44,7 +44,7 @@ module MultiFetchFragments
 
         result_hash = Rails.cache.read_multi(mutable_keys)
 
-        # if we had a cached value, we don't need to render that object from the collection. 
+        # if we had a cached value, we don't need to render that object from the collection.
         # if it wasn't cached, we need to render those objects as before
         result_hash.each do |key, value|
           if value

--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -25,8 +25,8 @@ module MultiFetchFragments
         @collection = @collection.clone
 
         @collection.each do |item|
-          key = @options[:cache].is_a?(Proc) ? @options[:cache].call(item) : item
- 
+          key = @options[:cache].respond_to?(:call) ? @options[:cache].call(item) : item
+
           key_with_optional_digest = nil
           if defined?(@view.fragment_name_with_digest)
             key_with_optional_digest = @view.fragment_name_with_digest(key)


### PR DESCRIPTION
This PR updates a few things, but mainly adds support for short-hand partial rendering.

Before, only the following syntax was supported:

``` ruby
<%= render partial: 'item', collection: @items, cache: true %>
```

Now, this is also supported:

``` ruby
<%= render @items, cache: true %>
```

Few other minor changes:
- Changed `is_a?(Proc)` to `respond_to?(:call)` for a bit more flexibility.
- Enabled using `cache: false` for easy collection caching toggling.
- Removed some trailing whitespace.
- Added ruby syntax highlighting to docs.

Let me know if you want any of these extra commits removed.
