### PR TITLE
Rails 4 fix.

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -27,6 +27,8 @@ module MultiFetchFragments
           key_with_optional_digest = nil
           if defined?(@view.fragment_name_with_digest)
             key_with_optional_digest = @view.fragment_name_with_digest(key)
+          elsif defined?(@view.cache_fragment_name)
+            key_with_optional_digest = @view.cache_fragment_name(key)
           else
             key_with_optional_digest = key
           end


### PR DESCRIPTION
The functionality of cache_digests has been brought to Rails 4 with some changes.

One change from the cache_digests gem is the method you use to get a cache digest. In Rails 4 you use `cache_fragment_name` while with cache_digests you call `fragment_name_with_digest`.
