### PR TITLE
Fix issue where RedisStore is expecting a splatted array

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -41,7 +41,12 @@ module MultiFetchFragments
         # cache.read_multi & cache.write interfaces may require mutable keys, ie. dalli 2.6.0
         mutable_keys = keys_to_collection_map.keys.collect { |key| key.dup }
 
-        result_hash = Rails.cache.read_multi(mutable_keys)
+				
+        result_hash = if defined? ActiveSupport::Cache::RedisStore
+												Rails.cache.read_multi(*mutable_keys)
+											else
+												Rails.cache.read_multi(mutable_keys)
+											end
 
         # if we had a cached value, we don't need to render that object from the collection.
         # if it wasn't cached, we need to render those objects as before


### PR DESCRIPTION
ActiveSupport::Cache::RedisStore is not expecting an array and throws undefined metod #match for Array
