### PR TITLE
Fix for cache_options issue

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -18,7 +18,7 @@ module MultiFetchFragments
 
       if cache_collection?
 
-        additional_cache_options = @options.fetch(:cache_options, {})
+        additional_cache_options = @options[:cache_options] || @locals[:cache_options] || {}
         keys_to_collection_map = {}
 
         @collection.each do |item|


### PR DESCRIPTION
Not sure if it's just in Rails 4, but the cache_options key is no longer available under @options, but instead @locals, so I've modified the code to check both.

Initially raised in issue #22
