### PR TITLE
Fixing failing spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,67 @@
+PATH
+  remote: .
+  specs:
+    multi_fetch_fragments (0.0.17)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    actionpack (4.1.6)
+      actionview (= 4.1.6)
+      activesupport (= 4.1.6)
+      rack (~> 1.5.2)
+      rack-test (~> 0.6.2)
+    actionview (4.1.6)
+      activesupport (= 4.1.6)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+    activemodel (4.1.6)
+      activesupport (= 4.1.6)
+      builder (~> 3.1)
+    activesupport (4.1.6)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    erubis (2.7.0)
+    i18n (0.6.11)
+    json (1.8.1)
+    minitest (5.4.2)
+    rack (1.5.2)
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    railties (4.1.6)
+      actionpack (= 4.1.6)
+      activesupport (= 4.1.6)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (10.3.2)
+    rspec-collection_matchers (1.0.0)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.2)
+    rspec-rails (2.99.0)
+      actionpack (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-collection_matchers
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    thor (0.19.1)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  multi_fetch_fragments!
+  rspec-rails (~> 2)

--- a/spec/multi_fetch_fragments_spec.rb
+++ b/spec/multi_fetch_fragments_spec.rb
@@ -9,8 +9,8 @@ describe MultiFetchFragments do
   end
 
   it "works for passing in a custom key" do
-    cache_mock = mock()
-    RAILS_CACHE = cache_mock
+    cache_mock = double()
+    Rails.cache = cache_mock
     MultiFetchFragments::Railtie.run_initializers
 
     controller = ActionController::Base.new
@@ -18,7 +18,7 @@ describe MultiFetchFragments do
 
     customer = Customer.new("david")
     key = controller.fragment_cache_key([customer, 'key'])
-    
+
     cache_mock.should_receive(:read_multi).with(key).and_return({key => 'Hello'})
 
     view.render(:partial => "views/customer", :collection => [ customer ], :cache => Proc.new{ |item| [item, 'key']}).should == "Hello"


### PR DESCRIPTION
I checked out this project  to make a pull request, but ended up getting a failing spec. The first error I got was the following

```
  1) MultiFetchFragments works for passing in a custom key
     Failure/Error: cache_mock = mock()
     NoMethodError:
       undefined method `mock' for #<RSpec::ExampleGroups::MultiFetchFragments:0x007fc4a30a8b50>
     # ./spec/multi_fetch_fragments_spec.rb:12:in `block (2 levels) in <top (required)>'
```

I changed the mock call to double() and then got this error

```
  1) MultiFetchFragments works for passing in a custom key
     Failure/Error: view.render(:partial => "views/customer", :collection => [ customer ], :cache => Proc.new{ |item| [item, 'key']}).should == "Hello"
     NoMethodError:
       undefined method `read_multi' for nil:NilClass
     # ./lib/multi_fetch_fragments.rb:45:in `render_collection_with_multi_fetch_cache'
     # ./spec/multi_fetch_fragments_spec.rb:24:in `block (2 levels) in <top (required)>'
```

To fix that, I set `Rails.cache` to the cache mock variable and everything started passing again.

I also included a Gemfile.lock anyone who pulls down the gem for development, will be using the same version of rspec.
